### PR TITLE
fix alcotest dependency declaration

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -15,5 +15,5 @@
  (name olinkcheck)
  (synopsis "A tool to detect broken URLs in markdown")
  (description "This tool finds all URLs in markdown files and checks if they are valid by pinging them.")
- (depends ocaml dune omd alcotest :with-test))
+ (depends ocaml dune omd (alcotest :with-test)))
 

--- a/olinkcheck.opam
+++ b/olinkcheck.opam
@@ -11,8 +11,7 @@ depends: [
   "ocaml"
   "dune" {>= "3.7"}
   "omd"
-  "alcotest"
-  ":with-test"
+  "alcotest" {with-test}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
The generated opam file is wrong. `with-test` is a package variable.