### PR TITLE
fixes in link handling

### DIFF
--- a/lib/plaintext.ml
+++ b/lib/plaintext.ml
@@ -8,7 +8,8 @@ let url_regexp =
     (Re.Perl.re
        {|https?://(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b((\.[-a-zA-Z0-9()@:%_\+~#?&//=]+)|([-a-zA-Z0-9()@:%_\+~#?&//=]))*|})
 
-let extract_links = Re.matches url_regexp
+let extract_links s =
+  List.map Utils.trim_trailing_whitespace (Re.matches url_regexp s)
 
 let replace_in_split (i, v) text =
   match (text, v) with

--- a/lib/plaintext.ml
+++ b/lib/plaintext.ml
@@ -6,7 +6,7 @@ let link_delimiter = ""
 let url_regexp =
   Re.compile
     (Re.Perl.re
-       {|https?://(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b((\.[-a-zA-Z0-9()@:%_\+~#?&//=]+)|([-a-zA-Z0-9()@:%_\+~#?&//=]))*|})
+       {|https?://(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b((\.[-a-zA-Z0-9()@:%_\+\*~#?&//=]+)|([-a-zA-Z0-9()@:%_\+\*~#?&//=]))*|})
 
 let extract_links s =
   List.map Utils.trim_trailing_whitespace (Re.matches url_regexp s)

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -8,6 +8,27 @@ let starts_with ~prefix s =
   in
   len_s >= len_pre && aux 0
 
+let ends_with ~suffix s =
+  let len_s = String.length s and len_suf = String.length suffix in
+  let diff = len_s - len_suf in
+  let rec aux i =
+    if i = len_suf then true
+    else if String.get s (diff + i) <> String.get suffix i then false
+    else aux (i + 1)
+  in
+  diff >= 0 && aux 0
+
+let trim_trailing_whitespace s =
+  let has_trailing_ws s =
+    ends_with ~suffix:"%20" s || ends_with ~suffix:"%0A" s
+    || ends_with ~suffix:"%09" s || ends_with ~suffix:"%0B" s
+    || ends_with ~suffix:"%0D" s
+  in
+  let rec loop s =
+    if has_trailing_ws s then loop (String.sub s 0 (String.length s - 3)) else s
+  in
+  loop s
+
 let exclude_patterns exclude_list links =
   links
   |> List.filter (fun link ->

--- a/lib/utils.mli
+++ b/lib/utils.mli
@@ -1,3 +1,5 @@
 val starts_with : prefix:string -> string -> bool
+val ends_with : suffix:string -> string -> bool
+val trim_trailing_whitespace : string -> string
 val exclude_patterns : string list -> string list -> string list
 val read_bin : string -> string


### PR DESCRIPTION
* Some links are able to establish a connection but the server doesn't
send a response, causing the query to wait indefinitely. This commit
adds a timeout of 5 minutes for every request.
* Links which end in URL-encoded whitespaces will be stripped of the
whitespace before querying.