### PR TITLE
set User-Agent to that of a browser

### DIFF
--- a/lib/link.ml
+++ b/lib/link.ml
@@ -1,4 +1,12 @@
-let request url = Ezcurl_lwt.get ~url ()
+let request url =
+  Ezcurl_lwt.get
+    ~headers:
+      [
+        ( "User-Agent",
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+           (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36" );
+      ]
+    ~url ()
 
 let reason = function
   | 100 -> "Continue"


### PR DESCRIPTION
Some websites like amazon.com do not want to be queried with User-Agent curl. Closes #57 