### PR TITLE
use shorter function names and labelled arguments

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -42,7 +42,7 @@ let olinkcheck annotate_in_file verbose exclude_list format file =
   in
   match format with
   | Markdown -> `Ok (f (module Markdown) verbose exclude_list ".md" file)
-  | Plaintext -> `Ok (f (module Plaintext) verbose exclude_list ".md" file)
+  | Plaintext -> `Ok (f (module Plaintext) verbose exclude_list ".txt" file)
   | YamlMd -> `Ok (f (module YamlMd) verbose exclude_list ".md" file)
   | YamlHtml -> `Ok (f (module YamlHtml) verbose exclude_list ".md" file)
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -36,43 +36,15 @@ let exclude_list =
     & info [ "exclude-list" ] ~docv:"EXCLUDE-LIST" ~doc)
 
 let olinkcheck annotate_in_file verbose exclude_list format file =
+  let f =
+    if annotate_in_file then Utils.annotate_in_file
+    else Utils.pretty_print_link_status_from_file
+  in
   match format with
-  | Markdown ->
-      `Ok
-        (if annotate_in_file then
-           Markdown.(
-             Utils.annotate_in_file verbose exclude_list ".md" annotate file)
-         else
-           Markdown.(
-             Utils.pretty_print_link_status_from_file verbose exclude_list ".md"
-               from_string extract_links file))
-  | Plaintext ->
-      `Ok
-        (if annotate_in_file then
-           Plaintext.(
-             Utils.annotate_in_file verbose exclude_list ".txt" annotate file)
-         else
-           Plaintext.(
-             Utils.pretty_print_link_status_from_file verbose exclude_list
-               ".txt" from_string extract_links file))
-  | YamlMd ->
-      `Ok
-        (if annotate_in_file then
-           YamlMd.(
-             Utils.annotate_in_file verbose exclude_list ".md" annotate file)
-         else
-           YamlMd.(
-             Utils.pretty_print_link_status_from_file verbose exclude_list ".md"
-               from_string extract_links file))
-  | YamlHtml ->
-      `Ok
-        (if annotate_in_file then
-           YamlHtml.(
-             Utils.annotate_in_file verbose exclude_list ".md" annotate file)
-         else
-           YamlHtml.(
-             Utils.pretty_print_link_status_from_file verbose exclude_list ".md"
-               from_string extract_links file))
+  | Markdown -> `Ok (f (module Markdown) verbose exclude_list ".md" file)
+  | Plaintext -> `Ok (f (module Plaintext) verbose exclude_list ".md" file)
+  | YamlMd -> `Ok (f (module YamlMd) verbose exclude_list ".md" file)
+  | YamlHtml -> `Ok (f (module YamlHtml) verbose exclude_list ".md" file)
 
 let cmd =
   let doc = "Check the status of links in a file." in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -28,23 +28,24 @@ let annotate_in_file =
   let doc = "Annotate broken links in the file" in
   Arg.(value & flag & info [ "annotate" ] ~doc)
 
-let exclude_list =
+let exclude_file =
   let doc = "File containing URL patterns to avoid querying" in
   Arg.(
     value
     & opt (some file) None
     & info [ "exclude-list" ] ~docv:"EXCLUDE-LIST" ~doc)
 
-let olinkcheck annotate_in_file verbose exclude_list format file =
+let olinkcheck annotate_in_file verbose exclude_file format file =
   let f =
     if annotate_in_file then Utils.annotate_in_file
-    else Utils.pretty_print_link_status_from_file
+    else Utils.pp_link_status_file
   in
   match format with
-  | Markdown -> `Ok (f (module Markdown) verbose exclude_list ".md" file)
-  | Plaintext -> `Ok (f (module Plaintext) verbose exclude_list ".txt" file)
-  | YamlMd -> `Ok (f (module YamlMd) verbose exclude_list ".md" file)
-  | YamlHtml -> `Ok (f (module YamlHtml) verbose exclude_list ".md" file)
+  | Markdown -> `Ok (f (module Markdown) ~verbose ~exclude_file ~ext:".md" file)
+  | Plaintext ->
+      `Ok (f (module Plaintext) ~verbose ~exclude_file ~ext:".txt" file)
+  | YamlMd -> `Ok (f (module YamlMd) ~verbose ~exclude_file ~ext:".md" file)
+  | YamlHtml -> `Ok (f (module YamlHtml) ~verbose ~exclude_file ~ext:".md" file)
 
 let cmd =
   let doc = "Check the status of links in a file." in
@@ -52,7 +53,7 @@ let cmd =
   Cmd.v info
     Term.(
       ret
-        (const olinkcheck $ annotate_in_file $ verbose $ exclude_list $ format
+        (const olinkcheck $ annotate_in_file $ verbose $ exclude_file $ format
        $ file))
 
 let _ = exit (Cmd.eval cmd)

--- a/bin/utils.ml
+++ b/bin/utils.ml
@@ -1,53 +1,53 @@
 open Olinkcheck
 
-let pretty_print_link_status verbose (link, (status_code, status_string)) =
+let pp_link_status ?(verbose = false) (link, (status_code, status_string)) =
   if (not (verbose || status_code = 200)) || verbose then
     Printf.printf "%s - %i %s\n" link status_code status_string
   else ()
 
 let with_ext ext = List.filter (fun file -> Filename.extension file = ext)
 
-let rec files_with_ext ext file =
+let rec files_with_ext ~ext file =
   if Sys.is_directory file then
     try
       file |> Sys.readdir |> Array.to_list
       |> List.map (Filename.concat file)
       |> List.partition Sys.is_directory
       |> fun (dirs, non_dirs) ->
-      with_ext ext non_dirs @ List.concat @@ List.map (files_with_ext ext) dirs
+      with_ext ext non_dirs @ List.concat @@ List.map (files_with_ext ~ext) dirs
     with Sys_error _ -> []
   else if Filename.extension file = ext then [ file ]
   else []
 
-let read_exclude_list file =
+let read_exclude_prefixes file =
   match file with
   | Some file ->
       read_bin file |> String.split_on_char '\n'
       |> List.filter (fun pat -> pat <> "")
   | None -> []
 
-let pretty_print_link_status_from_file (type p)
-    (module M : Parser with type t = p) verbose exclude_list ext file =
-  let exclude_list = read_exclude_list exclude_list in
-  file |> files_with_ext ext
+let pp_link_status_file (type p) (module M : Parser with type t = p)
+    ?(verbose = false) ~exclude_file ~ext file =
+  let exclude_prefixes = read_exclude_prefixes exclude_file in
+  file |> files_with_ext ~ext
   |> List.iter (fun file ->
          try
            file |> read_bin |> M.from_string |> M.extract_links
-           |> exclude_patterns ~prefix_list:exclude_list
+           |> exclude_patterns ~prefixes:exclude_prefixes
            |> (fun links ->
                 print_endline file;
                 let statuses = Link.status_many links in
                 List.combine links statuses)
-           |> List.iter (pretty_print_link_status verbose)
+           |> List.iter (pp_link_status ~verbose)
          with Sys_error _ -> ())
 
-let annotate_in_file (type p) (module M : Parser with type t = p) verbose
-    exclude_list ext file =
-  let exclude_list = read_exclude_list exclude_list in
-  file |> files_with_ext ext
+let annotate_in_file (type p) (module M : Parser with type t = p)
+    ?(verbose = false) ~exclude_file ~ext file =
+  let exclude_prefixes = read_exclude_prefixes exclude_file in
+  file |> files_with_ext ~ext
   |> List.iter (fun file ->
          try
-           file |> read_bin |> M.(annotate ~verbose ~exclude_list) |> fst
+           file |> read_bin |> M.(annotate ~verbose ~exclude_prefixes) |> fst
            |> fun new_str ->
            let out_chan = open_out file in
            Printf.fprintf out_chan "%s" new_str;

--- a/bin/utils.ml
+++ b/bin/utils.ml
@@ -26,13 +26,13 @@ let read_exclude_list file =
       |> List.filter (fun pat -> pat <> "")
   | None -> []
 
-let pretty_print_link_status_from_file verbose exclude_list ext from_string
-    extract_links file =
+let pretty_print_link_status_from_file (type p)
+    (module M : Parser with type t = p) verbose exclude_list ext file =
   let exclude_list = read_exclude_list exclude_list in
   file |> files_with_ext ext
   |> List.iter (fun file ->
          try
-           file |> read_bin |> from_string |> extract_links
+           file |> read_bin |> M.from_string |> M.extract_links
            |> exclude_patterns exclude_list
            |> (fun links ->
                 print_endline file;
@@ -41,12 +41,13 @@ let pretty_print_link_status_from_file verbose exclude_list ext from_string
            |> List.iter (pretty_print_link_status verbose)
          with Sys_error _ -> ())
 
-let annotate_in_file verbose exclude_list ext annotate file =
+let annotate_in_file (type p) (module M : Parser with type t = p) verbose
+    exclude_list ext file =
   let exclude_list = read_exclude_list exclude_list in
   file |> files_with_ext ext
   |> List.iter (fun file ->
          try
-           file |> read_bin |> annotate verbose exclude_list |> fst
+           file |> read_bin |> M.(annotate ~verbose ~exclude_list) |> fst
            |> fun new_str ->
            let out_chan = open_out file in
            Printf.fprintf out_chan "%s" new_str;

--- a/bin/utils.ml
+++ b/bin/utils.ml
@@ -41,12 +41,12 @@ let pretty_print_link_status_from_file verbose exclude_list ext from_string
            |> List.iter (pretty_print_link_status verbose)
          with Sys_error _ -> ())
 
-let annotate_in_file verbose exclude_list ext annotate_in_str file =
+let annotate_in_file verbose exclude_list ext annotate file =
   let exclude_list = read_exclude_list exclude_list in
   file |> files_with_ext ext
   |> List.iter (fun file ->
          try
-           file |> read_bin |> annotate_in_str verbose exclude_list |> fst
+           file |> read_bin |> annotate verbose exclude_list |> fst
            |> fun new_str ->
            let out_chan = open_out file in
            Printf.fprintf out_chan "%s" new_str;

--- a/bin/utils.ml
+++ b/bin/utils.ml
@@ -33,7 +33,7 @@ let pretty_print_link_status_from_file (type p)
   |> List.iter (fun file ->
          try
            file |> read_bin |> M.from_string |> M.extract_links
-           |> exclude_patterns exclude_list
+           |> exclude_patterns ~prefix_list:exclude_list
            |> (fun links ->
                 print_endline file;
                 let statuses = Link.status_many links in

--- a/lib/olinkcheck.ml
+++ b/lib/olinkcheck.ml
@@ -15,21 +15,13 @@ module type Parser = sig
   type t
 
   val from_string : string -> t
-<<<<<<< HEAD
-=======
-  val link_delimiter : string
->>>>>>> f67f097 (refactor main)
   val extract_links : t -> string list
 
   val replace_links :
     ?start:int -> (int * string) list -> t -> (int * (int * string) list) * t
 
-<<<<<<< HEAD
-  val annotate : bool -> string list -> string -> string * int list
-=======
   val annotate :
     ?verbose:bool -> ?exclude_list:string list -> string -> string * int list
->>>>>>> f67f097 (refactor main)
 end
 
 module MakeParser (P : BasicParser) : Parser = struct
@@ -54,7 +46,8 @@ module MakeParser (P : BasicParser) : Parser = struct
   let annotate ?(verbose = false) ?(exclude_list = []) str =
     (*find the links and exclude based on the exclude list*)
     let links =
-      str |> from_string |> extract_links |> exclude_patterns exclude_list
+      str |> from_string |> extract_links
+      |> exclude_patterns ~prefix_list:exclude_list
     in
     (*get their status*)
     let status = Link.status_many links in
@@ -106,7 +99,6 @@ module MakeParser (P : BasicParser) : Parser = struct
          (str, [])
 end
 
-<<<<<<< HEAD
 module type ParserPair = sig
   module P1 : Parser
   module P2 : Parser
@@ -159,7 +151,7 @@ module MakePairParser (P : ParserPair) : Parser = struct
     in
     (p', List.rev ts')
 
-  let annotate verbose exclude_list str =
+  let annotate ?(verbose = false) ?(exclude_list = []) str =
     let parts = P.separate str in
     let annotated_parts, positions =
       List.fold_left
@@ -167,10 +159,10 @@ module MakePairParser (P : ParserPair) : Parser = struct
           let asp', pos' =
             match sp with
             | P.(P1_parsed x) ->
-                let c, d = P.P1.annotate verbose exclude_list x in
+                let c, d = P.P1.annotate ~verbose ~exclude_list x in
                 (P.(P1_parsed c), d)
             | P.(P2_parsed x) ->
-                let c, d = P.P2.annotate verbose exclude_list x in
+                let c, d = P.P2.annotate ~verbose ~exclude_list x in
                 (P.(P2_parsed c), d)
           in
           (asp' :: asps, pos' @ pos))
@@ -179,8 +171,6 @@ module MakePairParser (P : ParserPair) : Parser = struct
     (P.join (List.rev annotated_parts), positions)
 end
 
-=======
->>>>>>> f67f097 (refactor main)
 module Plaintext = MakeParser (Plaintext)
 module Markdown = MakeParser (Markdown)
 module Sexp = MakeParser (Sexp)

--- a/lib/olinkcheck.ml
+++ b/lib/olinkcheck.ml
@@ -15,12 +15,21 @@ module type Parser = sig
   type t
 
   val from_string : string -> t
+<<<<<<< HEAD
+=======
+  val link_delimiter : string
+>>>>>>> f67f097 (refactor main)
   val extract_links : t -> string list
 
   val replace_links :
     ?start:int -> (int * string) list -> t -> (int * (int * string) list) * t
 
+<<<<<<< HEAD
   val annotate : bool -> string list -> string -> string * int list
+=======
+  val annotate :
+    ?verbose:bool -> ?exclude_list:string list -> string -> string * int list
+>>>>>>> f67f097 (refactor main)
 end
 
 module MakeParser (P : BasicParser) : Parser = struct
@@ -42,7 +51,7 @@ module MakeParser (P : BasicParser) : Parser = struct
     in
     aux (Re.split_full regexp str) [] 0
 
-  let annotate verbose exclude_list str =
+  let annotate ?(verbose = false) ?(exclude_list = []) str =
     (*find the links and exclude based on the exclude list*)
     let links =
       str |> from_string |> extract_links |> exclude_patterns exclude_list
@@ -97,6 +106,7 @@ module MakeParser (P : BasicParser) : Parser = struct
          (str, [])
 end
 
+<<<<<<< HEAD
 module type ParserPair = sig
   module P1 : Parser
   module P2 : Parser
@@ -169,6 +179,8 @@ module MakePairParser (P : ParserPair) : Parser = struct
     (P.join (List.rev annotated_parts), positions)
 end
 
+=======
+>>>>>>> f67f097 (refactor main)
 module Plaintext = MakeParser (Plaintext)
 module Markdown = MakeParser (Markdown)
 module Sexp = MakeParser (Sexp)

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -29,12 +29,12 @@ let trim_trailing_whitespace s =
   in
   loop s
 
-let exclude_patterns exclude_list links =
+let exclude_patterns ?(prefix_list = []) links =
   links
   |> List.filter (fun link ->
          List.fold_left
            (fun ok prefix -> ok && not (starts_with ~prefix link))
-           true exclude_list)
+           true prefix_list)
 
 (** Adapted from {{: https://github.com/ocaml/ocaml/blob/5.1/stdlib/in_channel.ml#L83 } Ocaml 5.1 In_channel}*)
 let read_upto ic buf ofs len =

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -29,12 +29,12 @@ let trim_trailing_whitespace s =
   in
   loop s
 
-let exclude_patterns ?(prefix_list = []) links =
+let exclude_patterns ?(prefixes = []) links =
   links
   |> List.filter (fun link ->
          List.fold_left
            (fun ok prefix -> ok && not (starts_with ~prefix link))
-           true prefix_list)
+           true prefixes)
 
 (** Adapted from {{: https://github.com/ocaml/ocaml/blob/5.1/stdlib/in_channel.ml#L83 } Ocaml 5.1 In_channel}*)
 let read_upto ic buf ofs len =

--- a/lib/utils.mli
+++ b/lib/utils.mli
@@ -1,5 +1,5 @@
 val starts_with : prefix:string -> string -> bool
 val ends_with : suffix:string -> string -> bool
 val trim_trailing_whitespace : string -> string
-val exclude_patterns : string list -> string list -> string list
+val exclude_patterns : ?prefix_list:string list -> string list -> string list
 val read_bin : string -> string

--- a/lib/utils.mli
+++ b/lib/utils.mli
@@ -1,5 +1,5 @@
 val starts_with : prefix:string -> string -> bool
 val ends_with : suffix:string -> string -> bool
 val trim_trailing_whitespace : string -> string
-val exclude_patterns : ?prefix_list:string list -> string list -> string list
+val exclude_patterns : ?prefixes:string list -> string list -> string list
 val read_bin : string -> string

--- a/test/html_test.ml
+++ b/test/html_test.ml
@@ -1,11 +1,11 @@
 open Olinkcheck
 
-let test_empty_text () =
+let empty_text () =
   Alcotest.(check (list string))
     "same lists" []
     (Html.extract_links (Html.from_string ""))
 
-let test_text_without_links () =
+let text_without_links () =
   Alcotest.(check (list string))
     "same lists" []
     (Html.extract_links
@@ -13,7 +13,7 @@ let test_text_without_links () =
           "<html><p>this html</p><ul><li>does \
            not</li><li>have</li><li>links</li></ul></html>"))
 
-let test_text_with_links () =
+let text_with_links () =
   Alcotest.(check (list string))
     "same lists"
     [
@@ -26,7 +26,7 @@ let test_text_with_links () =
     ("test.html" |> Olinkcheck.read_bin |> Html.from_string
    |> Html.extract_links)
 
-let test_fix_links () =
+let fix_links () =
   let new_links =
     [
       "http://newlink1.com";

--- a/test/link_test.ml
+++ b/test/link_test.ml
@@ -1,4 +1,5 @@
 open Olinkcheck
+
 let http_statuses =
   [
     (101, "Switching Protocols");
@@ -90,6 +91,4 @@ let nonexistent_link () =
     "same pair" (404, "Not Found")
     (Link.status "http://google.com/does-not-exist")
 
-let invalid_link () =
-  Alcotest.(check int) "same code" 1 (fst (Link.status ""))
-
+let invalid_link () = Alcotest.(check int) "same code" 1 (fst (Link.status ""))

--- a/test/link_test.ml
+++ b/test/link_test.ml
@@ -61,7 +61,7 @@ let http_statuses =
     (511, "Network Authentication Required");
   ]
 
-let test_request_with_status (code, reason) =
+let request_with_status (code, reason) =
   let open Lwt.Syntax in
   let server url =
     let completed, signal = Lwt.wait () in
@@ -75,21 +75,21 @@ let test_request_with_status (code, reason) =
   in
   Lwt_main.run (Link.client server "http://127.0.0.1:8080/")
 
-let test_all_status_codes () =
+let all_status_codes () =
   Alcotest.(check (list (pair int string)))
     "same lists" http_statuses
-    (List.map test_request_with_status http_statuses)
+    (List.map request_with_status http_statuses)
 
-let test_valid_link () =
+let valid_link () =
   Alcotest.(check (pair int string))
     "same pair" (200, "OK")
     (Link.status "http://www.google.com")
 
-let test_nonexistent_link () =
+let nonexistent_link () =
   Alcotest.(check (pair int string))
     "same pair" (404, "Not Found")
     (Link.status "http://google.com/does-not-exist")
 
-let test_invalid_link () =
+let invalid_link () =
   Alcotest.(check int) "same code" 1 (fst (Link.status ""))
 

--- a/test/link_test.ml
+++ b/test/link_test.ml
@@ -1,0 +1,95 @@
+open Olinkcheck
+let http_statuses =
+  [
+    (101, "Switching Protocols");
+    (200, "OK");
+    (201, "Created");
+    (202, "Accepted");
+    (203, "Non-Authoritative Information");
+    (204, "No Content");
+    (205, "Reset Content");
+    (206, "Partial Content");
+    (207, "Multi-Status");
+    (208, "Already Reported");
+    (226, "226");
+    (300, "Multiple Choices");
+    (301, "Moved Permanently");
+    (302, "Found");
+    (303, "See Other");
+    (304, "Not Modified");
+    (305, "Use Proxy");
+    (307, "Temporary Redirect");
+    (308, "Permanent Redirect");
+    (400, "Bad Request");
+    (401, "Unauthorized");
+    (402, "Payment Required");
+    (403, "Forbidden");
+    (404, "Not Found");
+    (405, "Method Not Allowed");
+    (406, "Not Acceptable");
+    (407, "Proxy Authentication Required");
+    (408, "Request Timeout");
+    (409, "Conflict");
+    (410, "Gone");
+    (411, "Length Required");
+    (412, "Precondition Failed");
+    (413, "Payload Too Large");
+    (414, "URI Too Long");
+    (415, "Unsupported Media Type");
+    (416, "Range Not Satisfiable");
+    (417, "Expectation Failed");
+    (421, "Misdirected Request");
+    (422, "Unprocessable Entity");
+    (423, "Locked");
+    (424, "Failed Dependency");
+    (425, "Too Early");
+    (426, "Upgrade Required");
+    (428, "Precondition Required");
+    (429, "Too Many Requests");
+    (431, "Request Header Fields Too Large");
+    (451, "Unavailable For Legal Reasons");
+    (500, "Internal Server Error");
+    (501, "Not Implemented");
+    (502, "Bad Gateway");
+    (503, "Service Unavailable");
+    (504, "Gateway Timeout");
+    (505, "HTTP Version Not Supported");
+    (506, "Variant Also Negotiates");
+    (507, "Insufficient Storage");
+    (508, "Loop Detected");
+    (510, "Not Extended");
+    (511, "Network Authentication Required");
+  ]
+
+let test_request_with_status (code, reason) =
+  let open Lwt.Syntax in
+  let server url =
+    let completed, signal = Lwt.wait () in
+    let* webserver =
+      Server.webserver 8080 signal (string_of_int code ^ " " ^ reason)
+    in
+    let status = Link.request url in
+    let* () = completed in
+    let* () = Lwt_io.shutdown_server webserver in
+    status
+  in
+  Lwt_main.run (Link.client server "http://127.0.0.1:8080/")
+
+let test_all_status_codes () =
+  Alcotest.(check (list (pair int string)))
+    "same lists" http_statuses
+    (List.map test_request_with_status http_statuses)
+
+let test_valid_link () =
+  Alcotest.(check (pair int string))
+    "same pair" (200, "OK")
+    (Link.status "http://www.google.com")
+
+let test_nonexistent_link () =
+  Alcotest.(check (pair int string))
+    "same pair" (404, "Not Found")
+    (Link.status "http://google.com/does-not-exist")
+
+let test_invalid_link () =
+  Alcotest.(check int) "same code" 1 (fst (Link.status ""))
+

--- a/test/markdown_test.ml
+++ b/test/markdown_test.ml
@@ -1,11 +1,11 @@
 open Olinkcheck
 
-let test_empty_text () =
+let empty_text () =
   Alcotest.(check (list string))
     "same lists" []
     (Markdown.extract_links (Markdown.from_string ""))
 
-let test_text_without_links () =
+let text_without_links () =
   Alcotest.(check (list string))
     "same lists" []
     (Markdown.extract_links
@@ -13,7 +13,7 @@ let test_text_without_links () =
           "#Heading This text does not contain links. ![alt text](image.png) \
            is an image."))
 
-let test_text_with_links () =
+let text_with_links () =
   Alcotest.(check (list string))
     "same lists"
     [
@@ -34,7 +34,7 @@ let test_text_with_links () =
     ("test.md" |> Olinkcheck.read_bin |> Markdown.from_string
    |> Markdown.extract_links)
 
-let test_fix_links () =
+let fix_links () =
   let new_links =
     [
       "http://newlink1.com";

--- a/test/markdown_test.ml
+++ b/test/markdown_test.ml
@@ -60,7 +60,7 @@ let fix_links () =
      let _, transformed_md = Markdown.replace_links vs md in
      Markdown.extract_links transformed_md)
 
-let test_annotate () =
+let annotate () =
   let md =
     "[link1](http://www.google.com) and \
      [link2](http://www.google.com/does-not-exist), but not \
@@ -75,7 +75,7 @@ let test_annotate () =
     "same string" annotated_md
     (fst (Markdown.annotate false [] md))
 
-let test_verbose_annotate () =
+let verbose_annotate () =
   let md =
     "[link1](http://www.google.com) and \
      [link2](http://www.google.com/does-not-exist), but not \

--- a/test/markdown_test.ml
+++ b/test/markdown_test.ml
@@ -73,7 +73,7 @@ let annotate () =
   in
   Alcotest.(check string)
     "same string" annotated_md
-    (fst (Markdown.annotate false [] md))
+    (fst (Markdown.annotate md))
 
 let verbose_annotate () =
   let md =
@@ -88,4 +88,4 @@ let verbose_annotate () =
   in
   Alcotest.(check string)
     "same string" annotated_md
-    (fst (Markdown.annotate true [] md))
+    (fst (Markdown.annotate md))

--- a/test/markdown_test.ml
+++ b/test/markdown_test.ml
@@ -88,4 +88,4 @@ let verbose_annotate () =
   in
   Alcotest.(check string)
     "same string" annotated_md
-    (fst (Markdown.annotate md))
+    (fst (Markdown.annotate ~verbose:true md))

--- a/test/olinkcheck_test.ml
+++ b/test/olinkcheck_test.ml
@@ -8,8 +8,7 @@ let () =
             Markdown_test.text_without_links;
           Alcotest.test_case "Text with links" `Slow
             Markdown_test.text_with_links;
-          Alcotest.test_case "Test fix links" `Quick
-            Markdown_test.fix_links;
+          Alcotest.test_case "Test fix links" `Quick Markdown_test.fix_links;
           Alcotest.test_case "Annotate broken links" `Quick
             Markdown_test.annotate;
           Alcotest.test_case "Verbose annotate broken links" `Quick
@@ -22,8 +21,7 @@ let () =
             Plaintext_test.text_without_links;
           Alcotest.test_case "Text with links" `Slow
             Plaintext_test.text_with_links;
-          Alcotest.test_case "Test fix links" `Quick
-            Plaintext_test.fix_links;
+          Alcotest.test_case "Test fix links" `Quick Plaintext_test.fix_links;
           Alcotest.test_case "Annotate broken links" `Quick
             Plaintext_test.annotate;
           Alcotest.test_case "Verbose annotate broken links" `Quick
@@ -34,8 +32,7 @@ let () =
           Alcotest.test_case "Empty text" `Quick Sexp_test.empty_text;
           Alcotest.test_case "Text without links" `Quick
             Sexp_test.text_without_links;
-          Alcotest.test_case "Text with links" `Slow
-            Sexp_test.text_with_links;
+          Alcotest.test_case "Text with links" `Slow Sexp_test.text_with_links;
           Alcotest.test_case "Test fix links" `Quick Sexp_test.fix_links;
         ] );
       ( "yaml",
@@ -43,8 +40,7 @@ let () =
           Alcotest.test_case "Empty text" `Quick Yml_test.empty_text;
           Alcotest.test_case "Text without links" `Quick
             Yml_test.text_without_links;
-          Alcotest.test_case "Text with links" `Slow
-            Yml_test.text_with_links;
+          Alcotest.test_case "Text with links" `Slow Yml_test.text_with_links;
           Alcotest.test_case "Test fix links" `Quick Yml_test.fix_links;
         ] );
       ( "html",
@@ -52,8 +48,7 @@ let () =
           Alcotest.test_case "Empty text" `Quick Html_test.empty_text;
           Alcotest.test_case "Text without links" `Quick
             Html_test.text_without_links;
-          Alcotest.test_case "Text with links" `Slow
-            Html_test.text_with_links;
+          Alcotest.test_case "Text with links" `Slow Html_test.text_with_links;
           Alcotest.test_case "Test fix links" `Quick Html_test.fix_links;
         ] );
       ( "yaml_md",

--- a/test/olinkcheck_test.ml
+++ b/test/olinkcheck_test.ml
@@ -3,13 +3,13 @@ let () =
     [
       ( "markdown",
         [
-          Alcotest.test_case "Empty text" `Quick Markdown_test.test_empty_text;
+          Alcotest.test_case "Empty text" `Quick Markdown_test.empty_text;
           Alcotest.test_case "Text without links" `Quick
-            Markdown_test.test_text_without_links;
+            Markdown_test.text_without_links;
           Alcotest.test_case "Text with links" `Slow
-            Markdown_test.test_text_with_links;
+            Markdown_test.text_with_links;
           Alcotest.test_case "Test fix links" `Quick
-            Markdown_test.test_fix_links;
+            Markdown_test.fix_links;
           Alcotest.test_case "Annotate broken links" `Quick
             Markdown_test.test_annotate;
           Alcotest.test_case "Verbose annotate broken links" `Quick
@@ -17,13 +17,13 @@ let () =
         ] );
       ( "plaintext",
         [
-          Alcotest.test_case "Empty text" `Quick Plaintext_test.test_empty_text;
+          Alcotest.test_case "Empty text" `Quick Plaintext_test.empty_text;
           Alcotest.test_case "Text without links" `Quick
-            Plaintext_test.test_text_without_links;
+            Plaintext_test.text_without_links;
           Alcotest.test_case "Text with links" `Slow
-            Plaintext_test.test_text_with_links;
+            Plaintext_test.text_with_links;
           Alcotest.test_case "Test fix links" `Quick
-            Plaintext_test.test_fix_links;
+            Plaintext_test.fix_links;
           Alcotest.test_case "Annotate broken links" `Quick
             Plaintext_test.test_annotate;
           Alcotest.test_case "Verbose annotate broken links" `Quick
@@ -31,30 +31,30 @@ let () =
         ] );
       ( "sexp",
         [
-          Alcotest.test_case "Empty text" `Quick Sexp_test.test_empty_text;
+          Alcotest.test_case "Empty text" `Quick Sexp_test.empty_text;
           Alcotest.test_case "Text without links" `Quick
-            Sexp_test.test_text_without_links;
+            Sexp_test.text_without_links;
           Alcotest.test_case "Text with links" `Slow
-            Sexp_test.test_text_with_links;
-          Alcotest.test_case "Test fix links" `Quick Sexp_test.test_fix_links;
+            Sexp_test.text_with_links;
+          Alcotest.test_case "Test fix links" `Quick Sexp_test.fix_links;
         ] );
       ( "yaml",
         [
-          Alcotest.test_case "Empty text" `Quick Yml_test.test_empty_text;
+          Alcotest.test_case "Empty text" `Quick Yml_test.empty_text;
           Alcotest.test_case "Text without links" `Quick
-            Yml_test.test_text_without_links;
+            Yml_test.text_without_links;
           Alcotest.test_case "Text with links" `Slow
-            Yml_test.test_text_with_links;
-          Alcotest.test_case "Test fix links" `Quick Yml_test.test_fix_links;
+            Yml_test.text_with_links;
+          Alcotest.test_case "Test fix links" `Quick Yml_test.fix_links;
         ] );
       ( "html",
         [
-          Alcotest.test_case "Empty text" `Quick Html_test.test_empty_text;
+          Alcotest.test_case "Empty text" `Quick Html_test.empty_text;
           Alcotest.test_case "Text without links" `Quick
-            Html_test.test_text_without_links;
+            Html_test.text_without_links;
           Alcotest.test_case "Text with links" `Slow
-            Html_test.test_text_with_links;
-          Alcotest.test_case "Test fix links" `Quick Html_test.test_fix_links;
+            Html_test.text_with_links;
+          Alcotest.test_case "Test fix links" `Quick Html_test.fix_links;
         ] );
       ( "yaml_md",
         [
@@ -79,16 +79,16 @@ let () =
         ] );
       ( "link-status",
         [
-          Alcotest.test_case "Valid link" `Quick Link_test.test_valid_link;
-          Alcotest.test_case "Invalid link" `Quick Link_test.test_invalid_link;
+          Alcotest.test_case "Valid link" `Quick Link_test.valid_link;
+          Alcotest.test_case "Invalid link" `Quick Link_test.invalid_link;
           Alcotest.test_case "Non-existent link" `Quick
-            Link_test.test_nonexistent_link;
+            Link_test.nonexistent_link;
           Alcotest.test_case "All status codes" `Quick
-            Link_test.test_all_status_codes;
+            Link_test.all_status_codes;
         ] );
       ( "utils",
         [
           Alcotest.test_case "Exclude patterns" `Quick
-            Utils_test.test_exclude_patterns;
+            Utils_test.exclude_patterns;
         ] );
     ]

--- a/test/olinkcheck_test.ml
+++ b/test/olinkcheck_test.ml
@@ -11,9 +11,9 @@ let () =
           Alcotest.test_case "Test fix links" `Quick
             Markdown_test.fix_links;
           Alcotest.test_case "Annotate broken links" `Quick
-            Markdown_test.test_annotate;
+            Markdown_test.annotate;
           Alcotest.test_case "Verbose annotate broken links" `Quick
-            Markdown_test.test_verbose_annotate;
+            Markdown_test.verbose_annotate;
         ] );
       ( "plaintext",
         [
@@ -25,9 +25,9 @@ let () =
           Alcotest.test_case "Test fix links" `Quick
             Plaintext_test.fix_links;
           Alcotest.test_case "Annotate broken links" `Quick
-            Plaintext_test.test_annotate;
+            Plaintext_test.annotate;
           Alcotest.test_case "Verbose annotate broken links" `Quick
-            Plaintext_test.test_verbose_annotate;
+            Plaintext_test.verbose_annotate;
         ] );
       ( "sexp",
         [

--- a/test/olinkcheck_test.ml
+++ b/test/olinkcheck_test.ml
@@ -1,112 +1,3 @@
-open Olinkcheck
-
-let http_statuses =
-  [
-    (101, "Switching Protocols");
-    (200, "OK");
-    (201, "Created");
-    (202, "Accepted");
-    (203, "Non-Authoritative Information");
-    (204, "No Content");
-    (205, "Reset Content");
-    (206, "Partial Content");
-    (207, "Multi-Status");
-    (208, "Already Reported");
-    (226, "226");
-    (300, "Multiple Choices");
-    (301, "Moved Permanently");
-    (302, "Found");
-    (303, "See Other");
-    (304, "Not Modified");
-    (305, "Use Proxy");
-    (307, "Temporary Redirect");
-    (308, "Permanent Redirect");
-    (400, "Bad Request");
-    (401, "Unauthorized");
-    (402, "Payment Required");
-    (403, "Forbidden");
-    (404, "Not Found");
-    (405, "Method Not Allowed");
-    (406, "Not Acceptable");
-    (407, "Proxy Authentication Required");
-    (408, "Request Timeout");
-    (409, "Conflict");
-    (410, "Gone");
-    (411, "Length Required");
-    (412, "Precondition Failed");
-    (413, "Payload Too Large");
-    (414, "URI Too Long");
-    (415, "Unsupported Media Type");
-    (416, "Range Not Satisfiable");
-    (417, "Expectation Failed");
-    (421, "Misdirected Request");
-    (422, "Unprocessable Entity");
-    (423, "Locked");
-    (424, "Failed Dependency");
-    (425, "Too Early");
-    (426, "Upgrade Required");
-    (428, "Precondition Required");
-    (429, "Too Many Requests");
-    (431, "Request Header Fields Too Large");
-    (451, "Unavailable For Legal Reasons");
-    (500, "Internal Server Error");
-    (501, "Not Implemented");
-    (502, "Bad Gateway");
-    (503, "Service Unavailable");
-    (504, "Gateway Timeout");
-    (505, "HTTP Version Not Supported");
-    (506, "Variant Also Negotiates");
-    (507, "Insufficient Storage");
-    (508, "Loop Detected");
-    (510, "Not Extended");
-    (511, "Network Authentication Required");
-  ]
-
-let test_request_with_status (code, reason) =
-  let open Lwt.Syntax in
-  let server url =
-    let completed, signal = Lwt.wait () in
-    let* webserver =
-      Server.webserver 8080 signal (string_of_int code ^ " " ^ reason)
-    in
-    let status = Link.request url in
-    let* () = completed in
-    let* () = Lwt_io.shutdown_server webserver in
-    status
-  in
-  Lwt_main.run (Link.client server "http://127.0.0.1:8080/")
-
-let test_all_status_codes () =
-  Alcotest.(check (list (pair int string)))
-    "same lists" http_statuses
-    (List.map test_request_with_status http_statuses)
-
-let test_valid_link () =
-  Alcotest.(check (pair int string))
-    "same pair" (200, "OK")
-    (Link.status "http://www.google.com")
-
-let test_nonexistent_link () =
-  Alcotest.(check (pair int string))
-    "same pair" (404, "Not Found")
-    (Link.status "http://google.com/does-not-exist")
-
-let test_invalid_link () =
-  Alcotest.(check int) "same code" 1 (fst (Link.status ""))
-
-let test_exclude_patterns () =
-  Alcotest.(check (list string))
-    "same lists"
-    [ "http://link2.com"; "http://link3.com" ]
-    (exclude_patterns
-       [ "http://link1.com"; "http://link2.com/a" ]
-       [
-         "http://link1.com/a";
-         "http://link2.com";
-         "http://link2.com/ab";
-         "http://link3.com";
-       ])
-
 let () =
   Alcotest.run "Olinkcheck"
     [
@@ -188,12 +79,16 @@ let () =
         ] );
       ( "link-status",
         [
-          Alcotest.test_case "Valid link" `Quick test_valid_link;
-          Alcotest.test_case "Invalid link" `Quick test_invalid_link;
-          Alcotest.test_case "Non-existent link" `Quick test_nonexistent_link;
-          Alcotest.test_case "All status codes" `Quick test_all_status_codes;
+          Alcotest.test_case "Valid link" `Quick Link_test.test_valid_link;
+          Alcotest.test_case "Invalid link" `Quick Link_test.test_invalid_link;
+          Alcotest.test_case "Non-existent link" `Quick
+            Link_test.test_nonexistent_link;
+          Alcotest.test_case "All status codes" `Quick
+            Link_test.test_all_status_codes;
         ] );
       ( "utils",
-        [ Alcotest.test_case "Exclude patterns" `Quick test_exclude_patterns ]
-      );
+        [
+          Alcotest.test_case "Exclude patterns" `Quick
+            Utils_test.test_exclude_patterns;
+        ] );
     ]

--- a/test/plaintext_test.ml
+++ b/test/plaintext_test.ml
@@ -1,18 +1,18 @@
 open Olinkcheck
 
-let test_empty_text () =
+let empty_text () =
   Alcotest.(check (list string))
     "same lists" []
     (Plaintext.extract_links (Plaintext.from_string ""))
 
-let test_text_without_links () =
+let text_without_links () =
   Alcotest.(check (list string))
     "same lists" []
     (Plaintext.extract_links
        (Plaintext.from_string
           "This text does not contain any links. a://b.c is not a web link."))
 
-let test_text_with_links () =
+let text_with_links () =
   Alcotest.(check (list string))
     "same lists"
     [
@@ -28,7 +28,7 @@ let test_text_with_links () =
            on. However, only a part of \
            http://www.link4.com/a?b=c&]-not-matched is matched."))
 
-let test_fix_links () =
+let fix_links () =
   let new_links =
     [
       "http://newlink1.com";
@@ -38,17 +38,17 @@ let test_fix_links () =
   in
   Alcotest.(check (list string))
     "same lists" new_links
-    (let test_text =
+    (let text =
        Plaintext.from_string
          "This http://www.link1.com text contains   multiple https://link2.com \
           links. like. http://link3.com."
      in
      let ids = [ 0; 1; 2 ] in
      let vs = List.combine ids new_links in
-     let _, replaced_text = Plaintext.replace_links vs test_text in
+     let _, replaced_text = Plaintext.replace_links vs text in
      Plaintext.extract_links replaced_text)
 
-let test_annotate () =
+let annotate () =
   let str =
     "http://www.google.com, http://www.google.com/does and \
      http://www.google.com/does-not-exist."
@@ -61,7 +61,7 @@ let test_annotate () =
     "same string" annotated_str
     (fst (Plaintext.annotate false [] str))
 
-let test_verbose_annotate () =
+let verbose_annotate () =
   let str =
     "http://www.google.com, http://www.google.com/does and \
      http://www.google.com/does-not-exist."

--- a/test/plaintext_test.ml
+++ b/test/plaintext_test.ml
@@ -72,4 +72,4 @@ let verbose_annotate () =
   in
   Alcotest.(check string)
     "same string" annotated_str
-    (fst (Plaintext.annotate str))
+    (fst (Plaintext.annotate ~verbose:true str))

--- a/test/plaintext_test.ml
+++ b/test/plaintext_test.ml
@@ -59,7 +59,7 @@ let annotate () =
   in
   Alcotest.(check string)
     "same string" annotated_str
-    (fst (Plaintext.annotate false [] str))
+    (fst (Plaintext.annotate str))
 
 let verbose_annotate () =
   let str =
@@ -72,4 +72,4 @@ let verbose_annotate () =
   in
   Alcotest.(check string)
     "same string" annotated_str
-    (fst (Plaintext.annotate true [] str))
+    (fst (Plaintext.annotate str))

--- a/test/sexp_test.ml
+++ b/test/sexp_test.ml
@@ -1,18 +1,18 @@
 open Olinkcheck
 
-let test_empty_text () =
+let empty_text () =
   Alcotest.(check (list string))
     "same lists" []
     (Sexp.extract_links (Sexp.from_string ""))
 
-let test_text_without_links () =
+let text_without_links () =
   Alcotest.(check (list string))
     "same lists" []
     (Sexp.extract_links
        (Sexp.from_string
           "(this (sexp (does not contain links) a://b.c) is not a web link.)"))
 
-let test_text_with_links () =
+let text_with_links () =
   Alcotest.(check (list string))
     "same lists"
     [
@@ -27,7 +27,7 @@ let test_text_with_links () =
           "(http://link1.com)(url (http://link2.com))(url2 (nested \
            (http://link3.com)) adjacent http://link4.com (http://link5.com))"))
 
-let test_fix_links () =
+let fix_links () =
   let new_links =
     [
       "http://newlink1.com";

--- a/test/utils_test.ml
+++ b/test/utils_test.ml
@@ -1,0 +1,12 @@
+let test_exclude_patterns () =
+  Alcotest.(check (list string))
+    "same lists"
+    [ "http://link2.com"; "http://link3.com" ]
+    (Olinkcheck.exclude_patterns
+       [ "http://link1.com"; "http://link2.com/a" ]
+       [
+         "http://link1.com/a";
+         "http://link2.com";
+         "http://link2.com/ab";
+         "http://link3.com";
+       ])

--- a/test/utils_test.ml
+++ b/test/utils_test.ml
@@ -3,7 +3,7 @@ let exclude_patterns () =
     "same lists"
     [ "http://link2.com"; "http://link3.com" ]
     (Olinkcheck.exclude_patterns
-       ~prefix_list:[ "http://link1.com"; "http://link2.com/a" ]
+       ~prefixes:[ "http://link1.com"; "http://link2.com/a" ]
        [
          "http://link1.com/a";
          "http://link2.com";

--- a/test/utils_test.ml
+++ b/test/utils_test.ml
@@ -1,4 +1,4 @@
-let test_exclude_patterns () =
+let exclude_patterns () =
   Alcotest.(check (list string))
     "same lists"
     [ "http://link2.com"; "http://link3.com" ]

--- a/test/utils_test.ml
+++ b/test/utils_test.ml
@@ -3,7 +3,7 @@ let exclude_patterns () =
     "same lists"
     [ "http://link2.com"; "http://link3.com" ]
     (Olinkcheck.exclude_patterns
-       [ "http://link1.com"; "http://link2.com/a" ]
+       ~prefix_list:[ "http://link1.com"; "http://link2.com/a" ]
        [
          "http://link1.com/a";
          "http://link2.com";

--- a/test/yaml_html_test.ml
+++ b/test/yaml_html_test.ml
@@ -65,7 +65,7 @@ let test_annotate () =
   in
   Alcotest.(check string)
     "same string" annotated_md
-    (fst (YamlHtml.annotate false [] md))
+    (fst (YamlHtml.annotate md))
 
 let test_verbose_annotate () =
   let md = read_bin "yaml_html_2.md" in
@@ -84,4 +84,4 @@ let test_verbose_annotate () =
   in
   Alcotest.(check string)
     "same string" annotated_md
-    (fst (YamlHtml.annotate true [] md))
+    (fst (YamlHtml.annotate ~verbose:true md))

--- a/test/yaml_md_test.ml
+++ b/test/yaml_md_test.ml
@@ -74,9 +74,7 @@ let test_annotate () =
      [link2](http://www.google.com/does-not-exist - [404 Not Found]), but not \
      http://www.google.com/does-not-exist-too\n"
   in
-  Alcotest.(check string)
-    "same string" annotated_md
-    (fst (YamlMd.annotate false [] md))
+  Alcotest.(check string) "same string" annotated_md (fst (YamlMd.annotate md))
 
 let test_verbose_annotate () =
   let md = read_bin "yaml_md_2.md" in
@@ -91,4 +89,4 @@ let test_verbose_annotate () =
   in
   Alcotest.(check string)
     "same string" annotated_md
-    (fst (YamlMd.annotate true [] md))
+    (fst (YamlMd.annotate ~verbose:true md))

--- a/test/yml_test.ml
+++ b/test/yml_test.ml
@@ -1,17 +1,17 @@
 open Olinkcheck
 
-let test_empty_text () =
+let empty_text () =
   Alcotest.(check (list string))
     "same lists" []
     (Yaml.extract_links (Yaml.from_string ""))
 
-let test_text_without_links () =
+let text_without_links () =
   Alcotest.(check (list string))
     "same lists" []
     (Yaml.extract_links
        (Yaml.from_string "this: yaml\ndoc: \n- does: not\n- contain: links"))
 
-let test_text_with_links () =
+let text_with_links () =
   Alcotest.(check (list string))
     "same lists"
     [
@@ -25,7 +25,7 @@ let test_text_with_links () =
     ("test.yaml" |> Olinkcheck.read_bin |> Yaml.from_string
    |> Yaml.extract_links)
 
-let test_fix_links () =
+let fix_links () =
   let new_links =
     [
       "http://newlink1.com";


### PR DESCRIPTION
Towards #61 

- [x] Move tests of `Link` module to a separate file
- [x] Use named parameters in places where the signature doesn't make it clear
- [x] Use shorter function names